### PR TITLE
Add target language preferences

### DIFF
--- a/sopel_deepl/plugin.py
+++ b/sopel_deepl/plugin.py
@@ -1,8 +1,12 @@
 """sopel-deepl
 
 DeepL translation plugin for Sopel IRC bots.
+
+Licensed under the Eiffel Forum License 2.
+
+Copyright 2021-2024 dgw, technobabbl.es
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import deepl_api
 import requests.exceptions
@@ -18,13 +22,19 @@ LOGGER = get_logger('deepl')
 class DeepLSection(types.StaticSection):
     auth_key = types.ValidatedAttribute('auth_key', default=types.NO_DEFAULT)
     """Your DeepL account's Authentication Key."""
+    default_target = types.ValidatedAttribute('default_target', default='EN-US')
+    """The bot-wide default target language code."""
 
 
 def configure(config):
     config.define_section('deepl', DeepLSection, validate=False)
     config.deepl.configure_setting(
         'auth_key',
-        "Enter your DeepL account's Authentication Key:",
+        "Enter your DeepL API Key:",
+    )
+    config.deepl.configure_setting(
+        'default_target',
+        'Enter the default target language code:',
     )
 
 
@@ -47,7 +57,7 @@ def deepl_command(bot, trigger):
     try:
         translations = bot.memory['deepl_instance'].translate(
             texts=[text],
-            target_language='EN-US',
+            target_language=bot.config.deepl.default_target,
         )
     except deepl_api.exceptions.DeeplAuthorizationError:
         bot.reply(

--- a/sopel_deepl/util.py
+++ b/sopel_deepl/util.py
@@ -1,0 +1,54 @@
+"""sopel-deepl utility submodule
+
+Part of sopel-deepl.
+
+Licensed under the Eiffel Forum License 2.
+
+Copyright 2024 dgw, technobabbl.es
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sopel import SopelWrapper
+    from sopel.tools.identifiers import Identifier
+
+
+TARGET_SETTING_NAME = 'deepl_target'
+
+
+def get_preferred_target(
+    bot: SopelWrapper,
+    nick: Identifier | None,
+    context: Identifier | None,
+) -> str:
+    """Get the preferred target language for a user in a given context."""
+    if nick and (
+       target := bot.db.get_nick_value(nick, TARGET_SETTING_NAME, None)
+    ):
+        return target
+    elif context and (
+         target := bot.db.get_channel_value(context, TARGET_SETTING_NAME, None)
+    ):
+        return target
+    else:
+        return bot.settings.deepl.default_target
+
+
+def set_preferred_target(
+    bot: SopelWrapper,
+    context: Identifier,
+    target: str,
+) -> None:
+    """Set the preferred ``target`` language for a ``context`` (user or channel)."""
+    if context.is_nick():
+        if target == '-':
+            bot.db.delete_nick_value(context, TARGET_SETTING_NAME)
+        else:
+            bot.db.set_nick_value(context, TARGET_SETTING_NAME, target)
+    else:
+        if target == '-':
+            bot.db.delete_channel_value(context, TARGET_SETTING_NAME)
+        else:
+            bot.db.set_channel_value(context, TARGET_SETTING_NAME, target)


### PR DESCRIPTION
First, a bot-wide default, and then channel & user preferences.

Locally I have an untracked file splitting this into a `.config` submodule, but I'm not convinced finishing that is worth it. The config stuff doesn't add that much to `.plugin`, and would have to be imported anyway to work.