### PR TITLE
Switch to first-party `deepl` library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ keywords = [
 requires-python = ">=3.8, <4"
 dependencies = [
   "sopel>=8.0",
-  "deepl_api~=0.2.2",
+  "deepl~=1.22",
 ]
 
 [project.urls]


### PR DESCRIPTION
The advantage is, theoretically, active support from the service's developers. [`deepl` was last updated](https://pypi.org/project/deepl/1.22.0/) in April 2025, vs. the unofficial [`deepl-api`'s most recent release](https://pypi.org/project/deepl-api/0.2.4/) from February 2022.

DeepL's code repository still claims to support all the way back to Python 3.6, though their CI tests are currently disabled. The readme talks of removing support for EOL Python versions in 2024 (last year), so the project might not be *quite* as active as I thought... Hmm.

Closes #2 at any rate.